### PR TITLE
Fixed typo in header mapping servo2 to pin 0

### DIFF
--- a/examples/TrinketKnob/TrinketKnob.ino
+++ b/examples/TrinketKnob/TrinketKnob.ino
@@ -16,7 +16,7 @@
   As written, this is specifically for the Trinket although it should
   be Gemma or other boards (Arduino Uno, etc.) with proper pin mappings
  
-  Trinket:        USB+   Gnd   Pin #0  Pin #0  Pin #2 A1
+  Trinket:        USB+   Gnd   Pin #0  Pin #1  Pin #2 A1
   Connection:     Servo+  -   Servo1 Servo2   Potentiometer wiper
  
  *******************************************************************/


### PR DESCRIPTION
The mapping was confusing because it indicated the middle pin was Pin#0, but actually this is pin#1. So I fixed that line in the code. 
