### PR TITLE
Added range setting for servo pulse.

### DIFF
--- a/Adafruit_SoftServo.cpp
+++ b/Adafruit_SoftServo.cpp
@@ -15,6 +15,8 @@ Adafruit_SoftServo::Adafruit_SoftServo(void) {
   isAttached = false;
   servoPin = 255;
   angle = 90;
+  rangeLo = 1000;
+  rangeHi = 2000;
 }
 
 void Adafruit_SoftServo::attach(uint8_t pin) {
@@ -37,11 +39,21 @@ void Adafruit_SoftServo::write(uint8_t a) {
   angle = a;
 
   if (! isAttached) return;
-  micros = map(a, 0, 180, 1000, 2000);  
+  micros = map(a, 0, 180, rangeLo, rangeHi);
 }
 
 void Adafruit_SoftServo::refresh(void) {
   digitalWrite(servoPin, HIGH);
   delayMicroseconds(micros);
   digitalWrite(servoPin, LOW);
+}
+
+void Adafruit_SoftServo::setRangeMin(uint16_t lo)
+{
+  rangeLo = constrain(lo, 256, 3000);
+}
+
+void Adafruit_SoftServo::setRangeMax(uint16_t hi)
+{
+  rangeHi = constrain(hi, 256, 3000);
 }

--- a/Adafruit_SoftServo.h
+++ b/Adafruit_SoftServo.h
@@ -18,8 +18,12 @@ class Adafruit_SoftServo {
   boolean attached();
   void write(uint8_t a);
   void refresh(void);
+  void setRangeMin(uint16_t lo);
+  void setRangeMax(uint16_t hi);
  private:
   boolean isAttached;
   uint8_t servoPin, angle;
   uint16_t micros;
+  uint16_t rangeLo;
+  uint16_t rangeHi;
 };


### PR DESCRIPTION
Allow setting the pulse width for minimum and maximum servo
positions. This allows for full 0-180 movement for certain servos.
Without it my Gemma could only move an SG90 across about 90
degrees instead of its full 180+ degrees.
